### PR TITLE
Add sanitizer_proc to default_options

### DIFF
--- a/lib/amazon_ses_mailer/base.rb
+++ b/lib/amazon_ses_mailer/base.rb
@@ -77,6 +77,7 @@ module AmazonSesMailer
       return '' unless !!value
       return transform_hash(value) if value.is_a?(Hash)
       return transform_array(value) if value.is_a?(Array)
+      return default_options[:sanitizer_proc].call(value.to_s) if default_options[:sanitizer_proc].present?
       return value.to_s
     end
   end

--- a/lib/amazon_ses_mailer/base.rb
+++ b/lib/amazon_ses_mailer/base.rb
@@ -77,8 +77,13 @@ module AmazonSesMailer
       return '' unless !!value
       return transform_hash(value) if value.is_a?(Hash)
       return transform_array(value) if value.is_a?(Array)
-      return default_options[:sanitizer_proc].call(value.to_s) if default_options[:sanitizer_proc].present?
-      return value.to_s
+      return sanitize(value.to_s)
+    end
+
+    def sanitize(str)
+      escape_table = { "'" => '&#39;', '&' => '&amp;', '"' => '&quot;', '<' => '&lt;', '>' => '&gt;', }
+
+      str.gsub(/['&\"<>]/, escape_table)
     end
   end
 end

--- a/lib/amazon_ses_mailer/base.rb
+++ b/lib/amazon_ses_mailer/base.rb
@@ -81,9 +81,9 @@ module AmazonSesMailer
     end
 
     def sanitize(str)
-      escape_table = { "'" => '&#39;', '&' => '&amp;', '"' => '&quot;', '<' => '&lt;', '>' => '&gt;', }
+      @escape_table ||= { "'" => '&#39;', '&' => '&amp;', '"' => '&quot;', '<' => '&lt;', '>' => '&gt;', }
 
-      str.gsub(/['&\"<>]/, escape_table)
+      str.gsub(/['&\"<>]/, @escape_table)
     end
   end
 end

--- a/lib/amazon_ses_mailer/version.rb
+++ b/lib/amazon_ses_mailer/version.rb
@@ -1,3 +1,3 @@
 module AmazonSesMailer
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Email variables could contain HTML tags that were rendered within the email, leading to a security issue.
This PR escapes HTML to prevent this issues.