### PR TITLE
Update method_missing to accept keyword arguments

### DIFF
--- a/lib/amazon_ses_mailer/base.rb
+++ b/lib/amazon_ses_mailer/base.rb
@@ -34,9 +34,9 @@ module AmazonSesMailer
       @@__interceptors ||= []
     end
 
-    def self.method_missing(method_name, *args, &block)
+    def self.method_missing(method_name, *args, **kwargs, &block)
       template_name = [self.name, method_name].join('-')
-      new(template_name).send(method_name, *args, &block)
+      new(template_name).send(method_name, *args, **kwargs, &block)
     end
 
     def mail(options)

--- a/lib/amazon_ses_mailer/version.rb
+++ b/lib/amazon_ses_mailer/version.rb
@@ -1,3 +1,3 @@
 module AmazonSesMailer
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Update `method_missing` to accept keyword arguments to be ruby 3 compatible. 